### PR TITLE
doc: doc team structure and related projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,4 +37,5 @@ the organization.
   - A [nodejs/node](https://github.com/nodejs/node) clone for testing tools
     and bots.
 - [node-review](https://github.com/nodejs/node-review)
-  - Generate the metadata required for landing a Node.js Pull Request.
+  - A browser extension that generates the metadata required for landing
+    a Node.js Pull Request.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ the organization.
   - **@nodejs/automation-collaborators**: has write access to all
   automation-related repositories.
     - **@nodejs/automation-admins**: has admin access to all
-    automatino-related repositories.
+    automation-related repositories.
 
 ## Projects / Repositories
 

--- a/README.md
+++ b/README.md
@@ -4,12 +4,43 @@
 
 We are the @nodejs/automation team.
 
-## Purpose
+## About the Team
 
 The Node.js Automation Team focuses on building tools, bots and scripts that
 help Node.js collaborators maintain the Node.js project.
 
-## Projects
+The automation team is currently structured like this:
 
-To be discussed.
+- @nodejs/automation
+  - @nodejs/automation-collaborators
+    - @nodejs/automation-admins
 
+@nodejs/automation are the people to ping for automation-related issues in
+the organization.
+
+@nodejs/automation-collaborators has write access to all automation-related
+repositories.
+
+@nodejs/automation-admins has admin access to all automatino-related
+repositories.
+
+## Projects / Repositories
+
+- [automation](https://github.com/nodejs/automation)
+  - General discussions and documentations about automation.
+- [branch-diff](https://github.com/nodejs/branch-diff)
+  - A tool to list print the commits on one git branch that are not on
+    another using loose comparison.
+- [changelog-maker](https://github.com/nodejs/changelog-maker)
+  - A git log to CHANGELOG.md tool.
+- [commit-stream](https://github.com/nodejs/commit-stream)
+  - Turn a `git log` into a stream of commit objects.
+- [core-validate-commit](https://github.com/nodejs/core-validate-commit)
+  - Validate commit messages for Node.js core.
+- [github-bot](https://github.com/nodejs/github-bot)
+  - @nodejs-github-bot's heart and soul.
+- [node-auto-test](https://github.com/nodejs/node-auto-test)
+  - A [nodejs/node](https://github.com/nodejs/node) clone for testing tools
+    and bots.
+- [node-review](https://github.com/nodejs/node-review)
+  - Generate the metadata required for landing a Node.js Pull Request.

--- a/README.md
+++ b/README.md
@@ -11,18 +11,12 @@ help Node.js collaborators maintain the Node.js project.
 
 The automation team is currently structured like this:
 
-- @nodejs/automation
-  - @nodejs/automation-collaborators
-    - @nodejs/automation-admins
-
-@nodejs/automation are the people to ping for automation-related issues in
+- **@nodejs/automation**: people to ping for automation-related issues in
 the organization.
-
-@nodejs/automation-collaborators has write access to all automation-related
-repositories.
-
-@nodejs/automation-admins has admin access to all automatino-related
-repositories.
+  - **@nodejs/automation-collaborators**: has write access to all
+  automation-related repositories.
+    - **@nodejs/automation-admins**: has admin access to all
+    automatino-related repositories.
 
 ## Projects / Repositories
 


### PR DESCRIPTION
Fixes: https://github.com/nodejs/automation/issues/8
Refs: https://github.com/nodejs/automation/issues/1 (related projects)
Refs: https://github.com/nodejs/automation/issues/12 (monorepo proposal)
 
### Team structure

This is based on the idea proposed in https://github.com/nodejs/automation/issues/8#issuecomment-341423820. I have created the subteams described in the PR.

- The initial members in the two subteams @nodejs/automation-collaborators @nodejs/automation-admins are people in TSC and already in @nodejs/automation, because TSC are owners of the organization so they have write/admin access to these repos already.
- In addition I have added @rvagg who is both TSC and previous owners of commit stream, changelog-maker and branch-diff to both teams.
- If you want to join the subteams to get write/admin access, <del>please let me know on gitter or send me an email to the address in my profile.</del> I am not supposed to make the decision alone, will defer to another thread to discuss about this.

### Relate projects

- The documented related projects are automation-related projects that have already been transferred into the foundation. 
- To discuss about moving more outside projects, please reply in https://github.com/nodejs/automation/issues/1 or open a separate issue.
- If you do not think the documented projects should be owned by the automation team, please discuss here.
- To discuss about monorepo, please reply in https://github.com/nodejs/automation/issues/12. 
Until we come to a conclusion there, we will need to document the related projects separately.

The question of npm access seems to be less urgent, we can just ask the existing releasers to do the work and revisit later when there are not enough of them.